### PR TITLE
Feature shared element transitions of groups fragments with card list activity

### DIFF
--- a/app/src/main/java/com/globant/pokemontcgapp/activity/PokemonCardListActivity.kt
+++ b/app/src/main/java/com/globant/pokemontcgapp/activity/PokemonCardListActivity.kt
@@ -47,8 +47,14 @@ class PokemonCardListActivity : AppCompatActivity() {
     }
 
     private fun initUi(selection: String?, selectionColor: Int) {
-        binding.activityPokemonCardListAppBarTitle.text = selection
-        binding.activityPokemonCardListAppbarLayout.setBackgroundColor(ContextCompat.getColor(this, selectionColor))
+        val pokemonCardListCardView = binding.activityPokemonCardListCardView
+        supportPostponeEnterTransition()
+
+        binding.activityPokemonCardListCardViewTitle.text = selection
+        pokemonCardListCardView.setBackgroundColor(ContextCompat.getColor(this, selectionColor))
+        pokemonCardListCardView.transitionName = pokemonCardGroupSelected
+
+        supportStartPostponedEnterTransition()
     }
 
     private fun updateUI(data: Event<Data<List<PokemonCard>>>) {

--- a/app/src/main/java/com/globant/pokemontcgapp/adapter/PokemonSecondaryTypesAdapter.kt
+++ b/app/src/main/java/com/globant/pokemontcgapp/adapter/PokemonSecondaryTypesAdapter.kt
@@ -10,7 +10,7 @@ import com.globant.pokemontcgapp.R
 import com.globant.pokemontcgapp.databinding.PokemonSecondaryTypeElementBinding
 
 interface PokemonSecondaryTypeSelected {
-    fun onPokemonSecondaryTypeSelected(secondaryTypeSelected: SecondaryTypes)
+    fun onPokemonSecondaryTypeSelected(secondaryTypeSelected: SecondaryTypes, sharedView: View)
 }
 
 class PokemonSecondaryTypesAdapter(
@@ -39,7 +39,9 @@ class PokemonSecondaryTypesAdapter(
         private val binding = PokemonSecondaryTypeElementBinding.bind(itemView)
 
         fun bind(item: SecondaryTypes) = with(itemView) {
-            setOnClickListener { onSecondaryTypeClicked.onPokemonSecondaryTypeSelected(item) }
+            val pokemonSecondaryTypeCardView = binding.pokemonSecondaryTypeCardView
+            pokemonSecondaryTypeCardView.transitionName = item.name
+            setOnClickListener { onSecondaryTypeClicked.onPokemonSecondaryTypeSelected(item, pokemonSecondaryTypeCardView) }
             binding.pokemonSecondaryTypeTextViewName.text = item.name
             binding.pokemonSecondaryTypeCardView.setCardBackgroundColor(ContextCompat.getColor(context, item.bgColor))
         }

--- a/app/src/main/java/com/globant/pokemontcgapp/adapter/PokemonTypesAdapter.kt
+++ b/app/src/main/java/com/globant/pokemontcgapp/adapter/PokemonTypesAdapter.kt
@@ -12,7 +12,7 @@ import com.globant.pokemontcgapp.R
 import com.globant.pokemontcgapp.databinding.PokemonTypeElementBinding
 
 interface PokemonTypeSelected {
-    fun onPokemonTypeSelected(typeSelected: PokemonType)
+    fun onPokemonTypeSelected(typeSelected: PokemonType, sharedView: View)
 }
 
 class PokemonTypesAdapter(private val pokemonTypes: List<PokemonType>, private val onPokemonTypeClicked: PokemonTypeSelected) :
@@ -39,9 +39,11 @@ class PokemonTypesAdapter(private val pokemonTypes: List<PokemonType>, private v
         private val binding = PokemonTypeElementBinding.bind(itemView)
 
         fun bind(item: PokemonType) = with(itemView) {
-            setOnClickListener { onPokemonTypeClicked.onPokemonTypeSelected(item) }
+            val pokemonTypeCardView = binding.pokemonTypeCardView
+            pokemonTypeCardView.transitionName = item.name
+            setOnClickListener { onPokemonTypeClicked.onPokemonTypeSelected(item, pokemonTypeCardView) }
             binding.pokemonTypeTextViewName.text = item.name
-            binding.pokemonTypeCardView.setCardBackgroundColor(ContextCompat.getColor(context, item.bgColor))
+            pokemonTypeCardView.setCardBackgroundColor(ContextCompat.getColor(context, item.bgColor))
             Glide.with(context)
                 .load((item.image))
                 .transform(CircleCrop())

--- a/app/src/main/java/com/globant/pokemontcgapp/fragment/PokemonSubtypeFragment.kt
+++ b/app/src/main/java/com/globant/pokemontcgapp/fragment/PokemonSubtypeFragment.kt
@@ -1,10 +1,12 @@
 package com.globant.pokemontcgapp.fragment
 
+import android.app.ActivityOptions
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.GridLayoutManager
 import com.globant.domain.entity.SecondaryTypes
@@ -47,7 +49,7 @@ class PokemonSubtypeFragment : Fragment(), PokemonSecondaryTypeSelected {
             Status.LOADING -> binding.pokemonAlltypesLoading.visibility = View.VISIBLE
             Status.SUCCESS -> showPokemonSubtypes(pokemonSubtypesData.data)
             Status.ERROR -> showPokemonSubtypesError(pokemonSubtypesData.error?.message)
-            Status.ON_SUBTYPE_CLICKED -> pokemonSubtypesData.pokemonSubtype?.let { onSubtypeClicked(it) }
+            Status.ON_SUBTYPE_CLICKED -> pokemonSubtypesData.let { onSubtypeClicked(it.pokemonSubtype, it.sharedView) }
         }
     }
 
@@ -75,17 +77,21 @@ class PokemonSubtypeFragment : Fragment(), PokemonSecondaryTypeSelected {
         Toast.makeText(context, error, Toast.LENGTH_SHORT).show()
     }
 
-    override fun onPokemonSecondaryTypeSelected(secondaryTypeSelected: SecondaryTypes) {
-        pokemonSubtypeViewModel.onPokemonSubtypeSelected(secondaryTypeSelected)
+    override fun onPokemonSecondaryTypeSelected(secondaryTypeSelected: SecondaryTypes, sharedView: View) {
+        pokemonSubtypeViewModel.onPokemonSubtypeSelected(secondaryTypeSelected, sharedView)
     }
 
-    private fun onSubtypeClicked(subtypeSelected: SecondaryTypes) {
-        startActivity(
-            PokemonCardListActivity.getIntent(
-                requireContext(),
-                Triple(SUBTYPE, subtypeSelected.name, subtypeSelected.bgColor)
+    private fun onSubtypeClicked(subtypeSelected: SecondaryTypes?, sharedView: View?) {
+        subtypeSelected?.let {
+            startActivity(
+                PokemonCardListActivity.getIntent(
+                    requireContext(),
+                    Triple(SUBTYPE, subtypeSelected.name, subtypeSelected.bgColor)
+                ),
+                ActivityOptions.makeSceneTransitionAnimation(activity, sharedView, sharedView?.let { ViewCompat.getTransitionName(it) })
+                    .toBundle()
             )
-        )
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/globant/pokemontcgapp/fragment/PokemonSupertypeFragment.kt
+++ b/app/src/main/java/com/globant/pokemontcgapp/fragment/PokemonSupertypeFragment.kt
@@ -1,10 +1,12 @@
 package com.globant.pokemontcgapp.fragment
 
+import android.app.ActivityOptions
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.GridLayoutManager
 import com.globant.domain.entity.SecondaryTypes
@@ -48,7 +50,7 @@ class PokemonSupertypeFragment : Fragment(), PokemonSecondaryTypeSelected {
             Status.LOADING -> binding.pokemonAlltypesLoading.visibility = View.VISIBLE
             Status.SUCCESS -> showPokemonSupertypes(pokemonSupertypesData.data)
             Status.ERROR -> showPokemonSupertypesError(pokemonSupertypesData.error?.message)
-            Status.ON_SUPERTYPE_CLICKED -> pokemonSupertypesData.pokemonSupertype?.let { onSupertypeClicked(it) }
+            Status.ON_SUPERTYPE_CLICKED -> pokemonSupertypesData.let { onSupertypeClicked(it.pokemonSupertype, it.sharedView) }
         }
     }
 
@@ -76,17 +78,21 @@ class PokemonSupertypeFragment : Fragment(), PokemonSecondaryTypeSelected {
         Toast.makeText(context, error, Toast.LENGTH_SHORT).show()
     }
 
-    override fun onPokemonSecondaryTypeSelected(secondaryTypeSelected: SecondaryTypes) {
-        pokemonSupertypeViewModel.onPokemonSupertypeSelected(secondaryTypeSelected)
+    override fun onPokemonSecondaryTypeSelected(secondaryTypeSelected: SecondaryTypes, sharedView: View) {
+        pokemonSupertypeViewModel.onPokemonSupertypeSelected(secondaryTypeSelected, sharedView)
     }
 
-    private fun onSupertypeClicked(supertypeSelected: SecondaryTypes) {
-        startActivity(
-            PokemonCardListActivity.getIntent(
-                requireContext(),
-                Triple(SUPERTYPE, supertypeSelected.name, supertypeSelected.bgColor)
+    private fun onSupertypeClicked(supertypeSelected: SecondaryTypes?, sharedView: View?) {
+        supertypeSelected?.let {
+            startActivity(
+                PokemonCardListActivity.getIntent(
+                    requireContext(),
+                    Triple(SUPERTYPE, supertypeSelected.name, supertypeSelected.bgColor)
+                ),
+                ActivityOptions.makeSceneTransitionAnimation(activity, sharedView, sharedView?.let { ViewCompat.getTransitionName(it) })
+                    .toBundle()
             )
-        )
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/globant/pokemontcgapp/fragment/PokemonTypeFragment.kt
+++ b/app/src/main/java/com/globant/pokemontcgapp/fragment/PokemonTypeFragment.kt
@@ -1,10 +1,12 @@
 package com.globant.pokemontcgapp.fragment
 
+import android.app.ActivityOptions
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.GridLayoutManager
 import com.globant.domain.entity.PokemonType
@@ -48,7 +50,7 @@ class PokemonTypeFragment : Fragment(), PokemonTypeSelected {
             Status.LOADING -> binding.pokemonAlltypesLoading.visibility = View.VISIBLE
             Status.SUCCESS -> showPokemonTypes(pokemonTypesData.data)
             Status.ERROR -> showPokemonTypesError(pokemonTypesData.error?.message)
-            Status.ON_TYPE_CLICKED -> pokemonTypesData.pokemonType?.let { onTypeClicked(it) }
+            Status.ON_TYPE_CLICKED -> pokemonTypesData.let { onTypeClicked(it.pokemonType, it.sharedView) }
         }
     }
 
@@ -70,17 +72,21 @@ class PokemonTypeFragment : Fragment(), PokemonTypeSelected {
         Toast.makeText(context, error, Toast.LENGTH_SHORT).show()
     }
 
-    override fun onPokemonTypeSelected(typeSelected: PokemonType) {
-        pokemonTypeViewModel.onPokemonTypeSelected(typeSelected)
+    override fun onPokemonTypeSelected(typeSelected: PokemonType, sharedView: View) {
+        pokemonTypeViewModel.onPokemonTypeSelected(typeSelected, sharedView)
     }
 
-    private fun onTypeClicked(typeSelected: PokemonType) {
-        startActivity(
-            PokemonCardListActivity.getIntent(
-                requireContext(),
-                Triple(TYPE, typeSelected.name, typeSelected.bgColor)
+    private fun onTypeClicked(typeSelected: PokemonType?, sharedView: View?) {
+        typeSelected?.let { type ->
+            startActivity(
+                PokemonCardListActivity.getIntent(
+                    requireContext(),
+                    Triple(TYPE, type.name, type.bgColor)
+                ),
+                ActivityOptions.makeSceneTransitionAnimation(activity, sharedView, sharedView?.let { ViewCompat.getTransitionName(it) })
+                    .toBundle()
             )
-        )
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/globant/pokemontcgapp/viewmodel/PokemonSubtypeViewModel.kt
+++ b/app/src/main/java/com/globant/pokemontcgapp/viewmodel/PokemonSubtypeViewModel.kt
@@ -1,5 +1,6 @@
 package com.globant.pokemontcgapp.viewmodel
 
+import android.view.View
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -34,11 +35,12 @@ class PokemonSubtypeViewModel(private val getPokemonSubtypesUseCase: GetPokemonS
         }
     }
 
-    override fun onPokemonSubtypeSelected(subtypeSelected: SecondaryTypes) {
+    override fun onPokemonSubtypeSelected(subtypeSelected: SecondaryTypes, sharedView: View) {
         pokemonSubtypesMutableLiveData.value = Event(
             Data(
                 status = Status.ON_SUBTYPE_CLICKED,
-                pokemonSubtype = subtypeSelected
+                pokemonSubtype = subtypeSelected,
+                sharedView = sharedView
             )
         )
     }
@@ -46,6 +48,7 @@ class PokemonSubtypeViewModel(private val getPokemonSubtypesUseCase: GetPokemonS
     data class Data(
         var status: Status,
         var data: List<SecondaryTypes> = emptyList(),
+        var sharedView: View? = null,
         var error: Exception? = null,
         var pokemonSubtype: SecondaryTypes? = null
     )

--- a/app/src/main/java/com/globant/pokemontcgapp/viewmodel/PokemonSupertypeViewModel.kt
+++ b/app/src/main/java/com/globant/pokemontcgapp/viewmodel/PokemonSupertypeViewModel.kt
@@ -1,5 +1,6 @@
 package com.globant.pokemontcgapp.viewmodel
 
+import android.view.View
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -34,11 +35,12 @@ class PokemonSupertypeViewModel(private val getPokemonSupertypesUseCase: GetPoke
         }
     }
 
-    override fun onPokemonSupertypeSelected(supertypeSelected: SecondaryTypes) {
+    override fun onPokemonSupertypeSelected(supertypeSelected: SecondaryTypes, sharedView: View) {
         pokemonSupertypesMutableLiveData.value = Event(
             Data(
                 status = Status.ON_SUPERTYPE_CLICKED,
-                pokemonSupertype = supertypeSelected
+                pokemonSupertype = supertypeSelected,
+                sharedView = sharedView
             )
         )
     }
@@ -46,6 +48,7 @@ class PokemonSupertypeViewModel(private val getPokemonSupertypesUseCase: GetPoke
     data class Data(
         var status: Status,
         var data: List<SecondaryTypes> = emptyList(),
+        var sharedView: View? = null,
         var error: Exception? = null,
         var pokemonSupertype: SecondaryTypes? = null
     )

--- a/app/src/main/java/com/globant/pokemontcgapp/viewmodel/PokemonTypeViewModel.kt
+++ b/app/src/main/java/com/globant/pokemontcgapp/viewmodel/PokemonTypeViewModel.kt
@@ -1,5 +1,6 @@
 package com.globant.pokemontcgapp.viewmodel
 
+import android.view.View
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -32,13 +33,15 @@ class PokemonTypeViewModel(private val getPokemonTypesUseCase: GetPokemonTypesUs
         }
     }
 
-    override fun onPokemonTypeSelected(typeSelected: PokemonType) {
-        pokemonTypesMutableLiveData.value = Event(Data(status = Status.ON_TYPE_CLICKED, pokemonType = typeSelected))
+    override fun onPokemonTypeSelected(typeSelected: PokemonType, sharedView: View) {
+        pokemonTypesMutableLiveData.value =
+            Event(Data(status = Status.ON_TYPE_CLICKED, pokemonType = typeSelected, sharedView = sharedView))
     }
 
     data class Data(
         var status: Status,
         var data: List<PokemonType> = emptyList(),
+        var sharedView: View? = null,
         var error: Exception? = null,
         var pokemonType: PokemonType? = null
     )

--- a/app/src/main/java/com/globant/pokemontcgapp/viewmodel/contract/PokemonSubtypeContract.kt
+++ b/app/src/main/java/com/globant/pokemontcgapp/viewmodel/contract/PokemonSubtypeContract.kt
@@ -1,5 +1,6 @@
 package com.globant.pokemontcgapp.viewmodel.contract
 
+import android.view.View
 import androidx.lifecycle.LiveData
 import com.globant.domain.entity.SecondaryTypes
 import com.globant.pokemontcgapp.util.Event
@@ -10,6 +11,6 @@ interface PokemonSubtypeContract {
     interface ViewModel {
         fun getPokemonSubtypesLiveData(): LiveData<Event<Data>>
         fun getPokemonSubtypes(pokemonSubtypesResources: MutableMap<String, Int>): Job
-        fun onPokemonSubtypeSelected(subtypeSelected: SecondaryTypes)
+        fun onPokemonSubtypeSelected(subtypeSelected: SecondaryTypes, sharedView: View)
     }
 }

--- a/app/src/main/java/com/globant/pokemontcgapp/viewmodel/contract/PokemonSupertypeContract.kt
+++ b/app/src/main/java/com/globant/pokemontcgapp/viewmodel/contract/PokemonSupertypeContract.kt
@@ -1,5 +1,6 @@
 package com.globant.pokemontcgapp.viewmodel.contract
 
+import android.view.View
 import androidx.lifecycle.LiveData
 import com.globant.domain.entity.SecondaryTypes
 import com.globant.pokemontcgapp.util.Event
@@ -10,6 +11,6 @@ interface PokemonSupertypeContract {
     interface ViewModel {
         fun getPokemonSupertypesLiveData(): LiveData<Event<Data>>
         fun getPokemonSupertypes(pokemonSupertypesResources: MutableMap<String, Int>): Job
-        fun onPokemonSupertypeSelected(supertypeSelected: SecondaryTypes)
+        fun onPokemonSupertypeSelected(supertypeSelected: SecondaryTypes, sharedView: View)
     }
 }

--- a/app/src/main/java/com/globant/pokemontcgapp/viewmodel/contract/PokemonTypeContract.kt
+++ b/app/src/main/java/com/globant/pokemontcgapp/viewmodel/contract/PokemonTypeContract.kt
@@ -1,5 +1,6 @@
 package com.globant.pokemontcgapp.viewmodel.contract
 
+import android.view.View
 import androidx.lifecycle.LiveData
 import com.globant.domain.entity.PokemonType
 import com.globant.pokemontcgapp.util.Event
@@ -10,6 +11,6 @@ interface PokemonTypeContract {
     interface ViewModel {
         fun getPokemonTypesLiveData(): LiveData<Event<Data>>
         fun getPokemonTypes(pokemonTypesResources: MutableMap<String, Pair<Int, Int>>): Job
-        fun onPokemonTypeSelected(typeSelected: PokemonType)
+        fun onPokemonTypeSelected(typeSelected: PokemonType, sharedView: View)
     }
 }

--- a/app/src/main/res/layout/activity_pokemon_card_list.xml
+++ b/app/src/main/res/layout/activity_pokemon_card_list.xml
@@ -11,11 +11,12 @@
         android:layout_height="@dimen/activity_pokemon_card_list_title_icon_height"
         android:contentDescription="@string/app_name"
         android:src="@drawable/app_logo"
-        app:layout_constraintBottom_toTopOf="@+id/activity_pokemon_card_list_appbar_layout"
+        app:layout_constraintBottom_toTopOf="@+id/activity_pokemon_card_list_card_view"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/activity_pokemon_card_list_appbar_layout"
+    <androidx.cardview.widget.CardView
+        android:id="@+id/activity_pokemon_card_list_card_view"
+        style="@style/PokemonBaseCardView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/activity_pokemon_card_list_appbar_margin_top"
@@ -23,19 +24,19 @@
         app:layout_constraintTop_toBottomOf="@id/activity_pokemon_card_list_app_title_icon">
 
         <TextView
-            android:id="@+id/activity_pokemon_card_list_app_bar_title"
+            android:id="@+id/activity_pokemon_card_list_card_view_title"
             style="@style/TextViewCardListTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 
-    </com.google.android.material.appbar.AppBarLayout>
+    </androidx.cardview.widget.CardView>
 
     <androidx.constraintlayout.widget.Barrier
         android:id="@+id/activity_pokemon_card_list_barrier"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:barrierDirection="bottom"
-        app:constraint_referenced_ids="activity_pokemon_card_list_appbar_layout" />
+        app:constraint_referenced_ids="activity_pokemon_card_list_card_view" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/activity_pokemon_card_list_recycler_view"
@@ -49,12 +50,16 @@
     <RelativeLayout
         android:id="@+id/activity_pokemon_card_list_loading"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
         android:background="@color/loading_bg"
         android:elevation="@dimen/pokemon_loading_linear_elevation"
         android:gravity="center"
         android:orientation="vertical"
-        android:visibility="gone">
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/activity_pokemon_card_list_barrier">
 
         <ProgressBar
             android:id="@+id/activity_pokemon_card_list_progress_bar"

--- a/app/src/main/res/layout/pokemon_card_list_element.xml
+++ b/app/src/main/res/layout/pokemon_card_list_element.xml
@@ -4,8 +4,7 @@
     android:id="@+id/pokemon_type_card_view"
     style="@style/PokemonBaseCardView"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_gravity="center_horizontal">
+    android:layout_height="wrap_content">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -14,10 +13,9 @@
 
         <ImageView
             android:id="@+id/pokemon_card_list_image_view_image"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:contentDescription="@string/pokemon_type_image"
-            android:scaleType="fitXY"
             app:layout_constraintBottom_toTopOf="@id/pokemon_card_list_view_name"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -25,9 +23,9 @@
 
         <TextView
             android:id="@+id/pokemon_card_list_view_name"
-            style="@style/TextViewPokemonTypeElement"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            style="@style/TextViewCardListCardName"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:textColor="@color/loading_bg"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -21,4 +21,5 @@
     <dimen name="activity_pokemon_card_list_text_view_text_size">36sp</dimen>
     <dimen name="activity_pokemon_card_list_appbar_margin_top">10dp</dimen>
     <dimen name="activity_pokemon_card_list_title_icon_height">100dp</dimen>
+    <dimen name="activity_pokemon_card_list_element_card_name_text_view_text_size">36dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -21,5 +21,5 @@
     <dimen name="activity_pokemon_card_list_text_view_text_size">36sp</dimen>
     <dimen name="activity_pokemon_card_list_appbar_margin_top">10dp</dimen>
     <dimen name="activity_pokemon_card_list_title_icon_height">100dp</dimen>
-    <dimen name="activity_pokemon_card_list_element_card_name_text_view_text_size">36dp</dimen>
+    <dimen name="activity_pokemon_card_list_element_card_name_text_view_text_size">36sp</dimen>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -27,6 +27,7 @@
         <item name="cardMaxElevation">@dimen/pokemon_card_view_max_card_elevation</item>
         <item name="cardCornerRadius">@dimen/pokemon_card_view_corner_radius</item>
         <item name="android:layout_margin">@dimen/pokemon_card_layout_margin</item>
+        <item name="android:layout_gravity">center_horizontal</item>
     </style>
 
     <style name="BaseTextViewPokemonElement">
@@ -48,6 +49,10 @@
 
     <style name="TextViewCardListTitle" parent="BaseTextViewPokemonElement">
         <item name="android:textSize">@dimen/activity_pokemon_card_list_text_view_text_size</item>
+    </style>
+
+    <style name="TextViewCardListCardName" parent="BaseTextViewPokemonElement">
+        <item name="android:textSize">@dimen/activity_pokemon_card_list_element_card_name_text_view_text_size</item>
     </style>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -10,6 +10,7 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:windowDisablePreview">true</item>
+        <item name="android:windowContentTransitions">true</item>
     </style>
 
     <style name="AppTabLayout" parent="Widget.Design.TabLayout">

--- a/app/src/test/java/com/globant/pokemontcgapp/pokemonsubtypeviewmodeltest/PokemonSubtypeViewModelTest.kt
+++ b/app/src/test/java/com/globant/pokemontcgapp/pokemonsubtypeviewmodeltest/PokemonSubtypeViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.globant.pokemontcgapp.pokemonsubtypeviewmodeltest
 
+import android.view.View
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.globant.domain.database.PokemonSubtypeDatabase
 import com.globant.domain.entity.SecondaryTypes
@@ -51,6 +52,7 @@ class PokemonSubtypeViewModelTest {
     private val resultIsFailure: Result.Failure = mock()
     private val exception: Exception = mock()
     private val subtypeSelected: SecondaryTypes = SecondaryTypes(STADIUM, Color.pokemon_subtype_stadium)
+    private val sharedView: View = mock()
 
     @Before
     fun setUp() {
@@ -125,7 +127,7 @@ class PokemonSubtypeViewModelTest {
     fun `on onPokemonSubtypeSelected called`() {
         val liveDataUnderTest = viewModel.getPokemonSubtypesLiveData().testObserver()
 
-        viewModel.onPokemonSubtypeSelected(subtypeSelected)
+        sharedView?.let { viewModel.onPokemonSubtypeSelected(subtypeSelected, it) }
 
         assertEquals(Status.ON_SUBTYPE_CLICKED, liveDataUnderTest.observedValues[FIRST_RESPONSE]?.peekContent()?.status)
         assertEquals(subtypeSelected, liveDataUnderTest.observedValues[FIRST_RESPONSE]?.peekContent()?.pokemonSubtype)

--- a/app/src/test/java/com/globant/pokemontcgapp/pokemonsupertypeviewmodeltest/PokemonSupertypeViewModelTest.kt
+++ b/app/src/test/java/com/globant/pokemontcgapp/pokemonsupertypeviewmodeltest/PokemonSupertypeViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.globant.pokemontcgapp.pokemonsupertypeviewmodeltest
 
+import android.view.View
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.globant.domain.database.PokemonSupertypeDatabase
 import com.globant.domain.entity.SecondaryTypes
@@ -51,6 +52,7 @@ class PokemonSupertypeViewModelTest {
     private val resultIsFailure: Result.Failure = mock()
     private val exception: Exception = mock()
     private val supertypeSelected: SecondaryTypes = SecondaryTypes(Constant.TRAINER, Color.pokemon_supertype_trainer)
+    private val sharedView: View = mock()
 
     @Before
     fun setUp() {
@@ -125,7 +127,7 @@ class PokemonSupertypeViewModelTest {
     fun `on onPokemonSupertypeSelected called`() {
         val liveDataUnderTest = viewModel.getPokemonSupertypesLiveData().testObserver()
 
-        viewModel.onPokemonSupertypeSelected(supertypeSelected)
+        sharedView?.let { viewModel.onPokemonSupertypeSelected(supertypeSelected, it) }
 
         assertEquals(Status.ON_SUPERTYPE_CLICKED, liveDataUnderTest.observedValues[FIRST_RESPONSE]?.peekContent()?.status)
         assertEquals(supertypeSelected, liveDataUnderTest.observedValues[FIRST_RESPONSE]?.peekContent()?.pokemonSupertype)

--- a/app/src/test/java/com/globant/pokemontcgapp/pokemontypeviewmodeltest/PokemonTypeViewModelTest.kt
+++ b/app/src/test/java/com/globant/pokemontcgapp/pokemontypeviewmodeltest/PokemonTypeViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.globant.pokemontcgapp.pokemontypeviewmodeltest
 
+import android.view.View
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.globant.domain.database.PokemonTypeDatabase
 import com.globant.domain.entity.PokemonType
@@ -56,6 +57,7 @@ class PokemonTypeViewModelTest {
         Drawable.pokemon_colorless_type,
         Color.pokemon_type_colorless
     )
+    private val sharedView: View = mock()
 
     @Before
     fun setUp() {
@@ -130,9 +132,12 @@ class PokemonTypeViewModelTest {
     fun `on onPokemonTypeSelected called`() {
         val liveDataUnderTest = viewModel.getPokemonTypesLiveData().testObserver()
 
-        viewModel.onPokemonTypeSelected(typeSelected)
+        viewModel.onPokemonTypeSelected(typeSelected, sharedView)
 
-        assertEquals(Status.ON_TYPE_CLICKED, liveDataUnderTest.observedValues[FIRST_RESPONSE]?.peekContent()?.status)
+        assertEquals(
+            Status.ON_TYPE_CLICKED,
+            liveDataUnderTest.observedValues[FIRST_RESPONSE]?.peekContent()?.status
+        )
         assertEquals(typeSelected, liveDataUnderTest.observedValues[FIRST_RESPONSE]?.peekContent()?.pokemonType)
     }
 }


### PR DESCRIPTION
In this PR I implemented shared element transitions for the Pokemon Types/Supertypes/Subtypes Fragments with the Card List Activity.

GIF of the transitions:

![fixed size elements](https://user-images.githubusercontent.com/61156888/88829574-29d63500-d1a3-11ea-8ca4-6e57cd13da95.gif)

Tests passed and coverage:

<img width="257" alt="test passed transitions" src="https://user-images.githubusercontent.com/61156888/88815353-a7914500-d191-11ea-86ad-0f5eaebf3fad.png">

<img width="236" alt="coverage transitions" src="https://user-images.githubusercontent.com/61156888/88815359-a8c27200-d191-11ea-88ec-779c65610bad.png">