### PR TITLE
Marcos.cifuentes/feature pokemon card details activity service

### DIFF
--- a/app/src/main/java/com/globant/pokemontcgapp/activity/PokemonCardDetailActivity.kt
+++ b/app/src/main/java/com/globant/pokemontcgapp/activity/PokemonCardDetailActivity.kt
@@ -98,7 +98,7 @@ class PokemonCardDetailActivity : AppCompatActivity() {
                 activityPokemonCardDetailNumber.text =
                     getString(StringResource.activity_pokemon_card_detail_number_text, card.details?.number)
 
-                if (card.details?.artist == EMPTY_STRING) {
+                if (card.details?.artist.isNullOrEmpty()) {
                     activityPokemonCardDetailArtist.text =
                         getString(StringResource.activity_pokemon_card_detail_artist_text, UNIDENTIFIED)
                 } else {
@@ -106,7 +106,7 @@ class PokemonCardDetailActivity : AppCompatActivity() {
                         getString(StringResource.activity_pokemon_card_detail_artist_text, card.details?.artist)
                 }
 
-                if (card.details?.rarity == EMPTY_STRING) {
+                if (card.details?.rarity.isNullOrEmpty()) {
                     activityPokemonCardDetailRarity.text =
                         getString(StringResource.activity_pokemon_card_detail_rarity_text, UNIDENTIFIED)
                 } else {
@@ -131,7 +131,6 @@ class PokemonCardDetailActivity : AppCompatActivity() {
     }
 
     companion object {
-        private const val EMPTY_STRING = ""
         private const val NONE = "None"
         private const val UNIDENTIFIED = "Unidentified"
         fun getIntent(context: Context, data: String): Intent =

--- a/app/src/main/java/com/globant/pokemontcgapp/activity/PokemonCardDetailActivity.kt
+++ b/app/src/main/java/com/globant/pokemontcgapp/activity/PokemonCardDetailActivity.kt
@@ -8,7 +8,6 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.bumptech.glide.Glide
 import com.globant.domain.entity.PokemonCard
-import com.globant.domain.util.NONE
 import com.globant.pokemontcgapp.databinding.ActivityPokemonCardDetailBinding
 import com.globant.pokemontcgapp.util.Constant.POKEMON_CARD_ID
 import com.globant.pokemontcgapp.util.Drawable
@@ -62,7 +61,7 @@ class PokemonCardDetailActivity : AppCompatActivity() {
 
                 card.details?.nationalPokedexNumber?.let { pokedexNumber ->
                     activityPokemonCardDetailNationalPokedexNumber.apply {
-                        text = getString(StringResource.activity_pokemon_card_detail_national_pokedex_number_text, pokedexNumber)
+                        text = getString(StringResource.activity_pokemon_card_detail_national_pokedex_number_text, pokedexNumber.toString())
                         visibility = View.VISIBLE
                     }
                 }
@@ -87,21 +86,33 @@ class PokemonCardDetailActivity : AppCompatActivity() {
                     }
                 }
 
-                if (card.details?.healthPoints != NONE)
-                    activityPokemonCardDetailHp.apply {
-                        text =
-                            getString(StringResource.activity_pokemon_card_detail_hp_text, card.details?.healthPoints)
-                        visibility = View.VISIBLE
-                    }
+                card.details?.healthPoints?.let { healthPoints ->
+                    if (healthPoints != NONE)
+                        activityPokemonCardDetailHp.apply {
+                            text =
+                                getString(StringResource.activity_pokemon_card_detail_hp_text, healthPoints)
+                            visibility = View.VISIBLE
+                        }
+                }
 
                 activityPokemonCardDetailNumber.text =
                     getString(StringResource.activity_pokemon_card_detail_number_text, card.details?.number)
 
-                activityPokemonCardDetailArtist.text =
-                    getString(StringResource.activity_pokemon_card_detail_artist_text, card.details?.artist)
+                if (card.details?.artist == EMPTY_STRING) {
+                    activityPokemonCardDetailArtist.text =
+                        getString(StringResource.activity_pokemon_card_detail_artist_text, UNIDENTIFIED)
+                } else {
+                    activityPokemonCardDetailArtist.text =
+                        getString(StringResource.activity_pokemon_card_detail_artist_text, card.details?.artist)
+                }
 
-                activityPokemonCardDetailRarity.text =
-                    getString(StringResource.activity_pokemon_card_detail_rarity_text, card.details?.rarity)
+                if (card.details?.rarity == EMPTY_STRING) {
+                    activityPokemonCardDetailRarity.text =
+                        getString(StringResource.activity_pokemon_card_detail_rarity_text, UNIDENTIFIED)
+                } else {
+                    activityPokemonCardDetailRarity.text =
+                        getString(StringResource.activity_pokemon_card_detail_rarity_text, card.details?.rarity)
+                }
 
                 activityPokemonCardDetailSeries.text =
                     getString(StringResource.activity_pokemon_card_detail_series_text, card.details?.series)
@@ -120,6 +131,9 @@ class PokemonCardDetailActivity : AppCompatActivity() {
     }
 
     companion object {
+        private const val EMPTY_STRING = ""
+        private const val NONE = "None"
+        private const val UNIDENTIFIED = "Unidentified"
         fun getIntent(context: Context, data: String): Intent =
             Intent(context, PokemonCardDetailActivity::class.java).apply {
                 putExtra(POKEMON_CARD_ID, data)

--- a/app/src/main/java/com/globant/pokemontcgapp/di/KoinModules.kt
+++ b/app/src/main/java/com/globant/pokemontcgapp/di/KoinModules.kt
@@ -15,5 +15,5 @@ val viewModelModule = module {
     viewModel { PokemonSupertypeViewModel(get()) }
     viewModel { PokemonSubtypeViewModel(get()) }
     viewModel { PokemonCardListViewModel(get()) }
-    viewModel { PokemonCardDetailViewModel() }
+    viewModel { PokemonCardDetailViewModel(get()) }
 }

--- a/app/src/main/java/com/globant/pokemontcgapp/util/Constant.kt
+++ b/app/src/main/java/com/globant/pokemontcgapp/util/Constant.kt
@@ -1,8 +1,5 @@
 package com.globant.pokemontcgapp.util
 
-import com.globant.domain.entity.PokemonCard
-import com.globant.domain.entity.PokemonCardDetails
-
 object Constant {
     const val COLORLESS = "Colorless"
     const val WATER = "Water"
@@ -42,25 +39,5 @@ object Constant {
     const val POKEMON_GROUP = "pokemonGroup"
     const val SELECTION = "selection"
     const val SELECTION_COLOR = "selectionColor"
-    const val ID = "id"
-
-    val pokemonCard: PokemonCard = PokemonCard(
-        "xy7-4",
-        "Bellossom",
-        "https://images.pokemontcg.io/xy7/4.png",
-        "Grass",
-        "Pokémon",
-        "Stage 2",
-        PokemonCardDetails(
-            "182",
-            "Gloom",
-            "120",
-            "4",
-            "Mizue",
-            "Uncommon",
-            "XY",
-            "Ancient Origins",
-            "xy7"
-        )
-    )
+    const val POKEMON_CARD_ID = "pokemonCardId"
 }

--- a/app/src/main/java/com/globant/pokemontcgapp/viewmodel/PokemonCardDetailViewModel.kt
+++ b/app/src/main/java/com/globant/pokemontcgapp/viewmodel/PokemonCardDetailViewModel.kt
@@ -5,28 +5,39 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.globant.domain.entity.PokemonCard
-import com.globant.pokemontcgapp.util.Constant
+import com.globant.domain.usecase.GetPokemonCardDetailUseCase
+import com.globant.domain.util.Result
+import com.globant.pokemontcgapp.util.Event
 import com.globant.pokemontcgapp.viewmodel.contract.PokemonCardDetailContract
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
-class PokemonCardDetailViewModel :
+class PokemonCardDetailViewModel(private val getPokemonCardDetailUseCase: GetPokemonCardDetailUseCase) :
     ViewModel(), PokemonCardDetailContract.ViewModel {
 
-    private val pokemonCardMutableLiveData = MutableLiveData<Data>()
-    override fun getPokemonCardLiveData(): LiveData<Data> = pokemonCardMutableLiveData
+    private val pokemonCardMutableLiveData = MutableLiveData<Event<Data>>()
+    override fun getPokemonCardLiveData(): LiveData<Event<Data>> = pokemonCardMutableLiveData
 
-    override fun getPokemonCard() = viewModelScope.launch {
-        // TODO: Recover the card information from the API using a use case
-        pokemonCardMutableLiveData.value = Data(
-            Status.SUCCESS,
-            Constant.pokemonCard
-        )
+    override fun getPokemonCard(pokemonCardId: String) = viewModelScope.launch {
+        pokemonCardMutableLiveData.postValue(Event(Data(status = Status.LOADING)))
+        withContext(Dispatchers.IO) { getPokemonCardDetailUseCase.invoke(pokemonCardId) }.let { result ->
+            when (result) {
+                is Result.Success -> {
+                    pokemonCardMutableLiveData.postValue(Event(Data(status = Status.SUCCESS, data = result.data)))
+                }
+                is Result.Failure -> {
+                    pokemonCardMutableLiveData.postValue(Event(Data(status = Status.ERROR, error = result.exception)))
+                }
+            }
+        }
     }
 
-    data class Data(var status: Status, val data: PokemonCard)
+    data class Data(var status: Status, var data: PokemonCard? = null, var error: Exception? = null)
 
     enum class Status {
         LOADING,
-        SUCCESS
+        SUCCESS,
+        ERROR
     }
 }

--- a/app/src/main/java/com/globant/pokemontcgapp/viewmodel/contract/PokemonCardDetailContract.kt
+++ b/app/src/main/java/com/globant/pokemontcgapp/viewmodel/contract/PokemonCardDetailContract.kt
@@ -1,12 +1,13 @@
 package com.globant.pokemontcgapp.viewmodel.contract
 
 import androidx.lifecycle.LiveData
+import com.globant.pokemontcgapp.util.Event
 import com.globant.pokemontcgapp.viewmodel.PokemonCardDetailViewModel.Data
 import kotlinx.coroutines.Job
 
 interface PokemonCardDetailContract {
     interface ViewModel {
-        fun getPokemonCardLiveData(): LiveData<Data>
-        fun getPokemonCard(): Job
+        fun getPokemonCardLiveData(): LiveData<Event<Data>>
+        fun getPokemonCard(pokemonCardId: String): Job
     }
 }

--- a/app/src/main/res/layout/activity_pokemon_card_detail.xml
+++ b/app/src/main/res/layout/activity_pokemon_card_detail.xml
@@ -158,8 +158,6 @@
         android:orientation="vertical"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/activity_pokemon_card_detail_image">
 
         <ProgressBar

--- a/app/src/main/res/layout/activity_pokemon_card_detail.xml
+++ b/app/src/main/res/layout/activity_pokemon_card_detail.xml
@@ -148,9 +148,25 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 
-    <ProgressBar
-        android:id="@+id/activity_pokemon_card_detail_loader"
+    <RelativeLayout
+        android:id="@+id/activity_pokemon_card_detail_loading"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone" />
+        android:layout_height="0dp"
+        android:background="@color/loading_bg"
+        android:elevation="@dimen/pokemon_loading_linear_elevation"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/activity_pokemon_card_detail_image">
+
+        <ProgressBar
+            android:id="@+id/activity_pokemon_card_detail_progress_bar"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+    </RelativeLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_pokemon_card_list.xml
+++ b/app/src/main/res/layout/activity_pokemon_card_list.xml
@@ -57,8 +57,6 @@
         android:orientation="vertical"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/activity_pokemon_card_list_barrier">
 
         <ProgressBar

--- a/app/src/test/java/com/globant/pokemontcgapp/pokemoncarddetailviewmodeltest/PokemonCardDetailViewModelTest.kt
+++ b/app/src/test/java/com/globant/pokemontcgapp/pokemoncarddetailviewmodeltest/PokemonCardDetailViewModelTest.kt
@@ -1,12 +1,20 @@
 package com.globant.pokemontcgapp.pokemoncarddetailviewmodeltest
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.globant.domain.entity.PokemonCard
+import com.globant.domain.service.PokemonCardDetailService
+import com.globant.domain.usecase.GetPokemonCardDetailUseCase
+import com.globant.domain.usecase.implementation.GetPokemonCardDetailUseCaseImpl
 import com.globant.domain.util.FIRST_RESPONSE
+import com.globant.domain.util.Result
+import com.globant.domain.util.SECOND_RESPONSE
 import com.globant.pokemontcgapp.testObserver
-import com.globant.pokemontcgapp.util.Constant
 import com.globant.pokemontcgapp.viewmodel.PokemonCardDetailViewModel
 import com.globant.pokemontcgapp.viewmodel.PokemonCardDetailViewModel.Status
 import com.globant.pokemontcgapp.viewmodel.contract.PokemonCardDetailContract
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -31,11 +39,19 @@ class PokemonCardDetailViewModelTest {
     val taskExecutorRule = InstantTaskExecutorRule()
 
     private lateinit var viewModel: PokemonCardDetailContract.ViewModel
+    private lateinit var getPokemonCardDetailUseCase: GetPokemonCardDetailUseCase
+    private val mockedPokemonCardDetailService: PokemonCardDetailService = mock()
+    private val pokemonCard: PokemonCard = mock()
+    private val resultIsSuccess: Result.Success<PokemonCard> = mock()
+    private val resultIsFailure: Result.Failure = mock()
+    private val exception: Exception = mock()
+    private val pokemonCardId: String = ID
 
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
-        viewModel = PokemonCardDetailViewModel()
+        getPokemonCardDetailUseCase = GetPokemonCardDetailUseCaseImpl(mockedPokemonCardDetailService)
+        viewModel = PokemonCardDetailViewModel(getPokemonCardDetailUseCase)
     }
 
     @After
@@ -45,17 +61,38 @@ class PokemonCardDetailViewModelTest {
     }
 
     @Test
-    fun `on getPokemonCard called`() {
+    fun `on getPokemonCardDetail called successfully`() {
         val liveDataUnderTest = viewModel.getPokemonCardLiveData().testObserver()
 
+        whenever(getPokemonCardDetailUseCase.invoke(pokemonCardId)).thenReturn(resultIsSuccess)
+        whenever(resultIsSuccess.data).thenReturn(pokemonCard)
         runBlocking {
-            viewModel.getPokemonCard().join()
+            viewModel.getPokemonCard(pokemonCardId).join()
         }
 
-        assertEquals(Status.SUCCESS, liveDataUnderTest.observedValues[FIRST_RESPONSE]?.status)
-        assertEquals(
-            Constant.pokemonCard.name,
-            liveDataUnderTest.observedValues[FIRST_RESPONSE]?.data?.name
-        )
+        verify(mockedPokemonCardDetailService).getPokemonCardDetail(pokemonCardId)
+
+        assertEquals(Status.LOADING, liveDataUnderTest.observedValues[FIRST_RESPONSE]?.peekContent()?.status)
+        assertEquals(Status.SUCCESS, liveDataUnderTest.observedValues[SECOND_RESPONSE]?.peekContent()?.status)
+        assertEquals(pokemonCard, liveDataUnderTest.observedValues[SECOND_RESPONSE]?.peekContent()?.data)
+    }
+
+    @Test
+    fun `on getPokemonCardDetail called with error`() {
+        val liveDataUnderTest = viewModel.getPokemonCardLiveData().testObserver()
+
+        whenever(getPokemonCardDetailUseCase.invoke(pokemonCardId)).thenReturn(resultIsFailure)
+        whenever(resultIsFailure.exception).thenReturn(exception)
+        runBlocking {
+            viewModel.getPokemonCard(pokemonCardId).join()
+        }
+        verify(mockedPokemonCardDetailService).getPokemonCardDetail(pokemonCardId)
+
+        assertEquals(Status.LOADING, liveDataUnderTest.observedValues[FIRST_RESPONSE]?.peekContent()?.status)
+        assertEquals(Status.ERROR, liveDataUnderTest.observedValues[SECOND_RESPONSE]?.peekContent()?.status)
+    }
+
+    companion object {
+        private const val ID = "xy0-25"
     }
 }

--- a/app/src/test/java/com/globant/pokemontcgapp/pokemoncardlistviewmodeltest/PokemonCardListViewModelTest.kt
+++ b/app/src/test/java/com/globant/pokemontcgapp/pokemoncardlistviewmodeltest/PokemonCardListViewModelTest.kt
@@ -147,7 +147,7 @@ class PokemonCardListViewModelTest {
             "Pokémon",
             "Stage 2",
             PokemonCardDetails(
-                "182",
+                182,
                 "Gloom",
                 "120",
                 "4",

--- a/app/src/test/java/com/globant/pokemontcgapp/pokemoncardlistviewmodeltest/PokemonCardListViewModelTest.kt
+++ b/app/src/test/java/com/globant/pokemontcgapp/pokemoncardlistviewmodeltest/PokemonCardListViewModelTest.kt
@@ -3,6 +3,7 @@ package com.globant.pokemontcgapp.pokemoncardlistviewmodeltest
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.globant.domain.database.PokemonCardDatabase
 import com.globant.domain.entity.PokemonCard
+import com.globant.domain.entity.PokemonCardDetails
 import com.globant.domain.service.PokemonCardListService
 import com.globant.domain.usecase.GetPokemonCardListUseCase
 import com.globant.domain.usecase.implementation.GetPokemonCardListUseCaseImpl
@@ -10,7 +11,6 @@ import com.globant.domain.util.FIRST_RESPONSE
 import com.globant.domain.util.Result
 import com.globant.domain.util.SECOND_RESPONSE
 import com.globant.pokemontcgapp.testObserver
-import com.globant.pokemontcgapp.util.Constant
 import com.globant.pokemontcgapp.viewmodel.PokemonCardListViewModel
 import com.globant.pokemontcgapp.viewmodel.PokemonCardListViewModel.Status
 import com.globant.pokemontcgapp.viewmodel.contract.PokemonCardListContract
@@ -127,17 +127,36 @@ class PokemonCardListViewModelTest {
     fun `on onPokemonCardSelected called`() {
         val liveDataUnderTest = viewModel.getPokemonCardListLiveData().testObserver()
 
-        viewModel.onPokemonCardSelected(Constant.pokemonCard)
+        viewModel.onPokemonCardSelected(pokemonCard)
 
         assertEquals(
             Status.ON_CARD_CLICKED,
             liveDataUnderTest.observedValues[FIRST_RESPONSE]?.peekContent()?.status
         )
-        assertEquals(Constant.pokemonCard, liveDataUnderTest.observedValues[FIRST_RESPONSE]?.peekContent()?.pokemonCard)
+        assertEquals(pokemonCard, liveDataUnderTest.observedValues[FIRST_RESPONSE]?.peekContent()?.pokemonCard)
     }
 
     companion object {
         private const val TYPE = "types"
         private const val COLORLESS = "Colorless"
+        private val pokemonCard: PokemonCard = PokemonCard(
+            "xy7-4",
+            "Bellossom",
+            "https://images.pokemontcg.io/xy7/4.png",
+            "Grass",
+            "Pokémon",
+            "Stage 2",
+            PokemonCardDetails(
+                "182",
+                "Gloom",
+                "120",
+                "4",
+                "Mizue",
+                "Uncommon",
+                "XY",
+                "Ancient Origins",
+                "xy7"
+            )
+        )
     }
 }

--- a/data/src/main/java/com/globant/data/mapper/PokemonCardDetailsMapper.kt
+++ b/data/src/main/java/com/globant/data/mapper/PokemonCardDetailsMapper.kt
@@ -19,7 +19,7 @@ class PokemonCardDetailsMapper : BaseMapper<PokemonCardResponse, PokemonCard, Mu
         )
 
     private fun transformToDetails(type: PokemonCardResponse): PokemonCardDetails = PokemonCardDetails(
-        nationalPokedexNumber = type.nationalPokedexNumber.toString(),
+        nationalPokedexNumber = type.nationalPokedexNumber,
         evolvesFrom = type.evolvesFrom,
         healthPoints = type.hp,
         number = type.number,

--- a/data/src/main/java/com/globant/data/mapper/PokemonCardDetailsMapper.kt
+++ b/data/src/main/java/com/globant/data/mapper/PokemonCardDetailsMapper.kt
@@ -1,0 +1,36 @@
+package com.globant.data.mapper
+
+import com.globant.data.service.response.PokemonCardResponse
+import com.globant.domain.entity.PokemonCard
+import com.globant.domain.entity.PokemonCardDetails
+
+class PokemonCardDetailsMapper : BaseMapper<PokemonCardResponse, PokemonCard, MutableMap<String, Int>?> {
+
+    override fun transform(type: PokemonCardResponse, resources: MutableMap<String, Int>?): PokemonCard =
+
+        PokemonCard(
+            type.id,
+            type.name,
+            type.imageUrl,
+            type.types?.get(TYPE_VALUE),
+            type.supertype,
+            type.subtype,
+            transformToDetails(type)
+        )
+
+    private fun transformToDetails(type: PokemonCardResponse): PokemonCardDetails = PokemonCardDetails(
+        nationalPokedexNumber = type.nationalPokedexNumber.toString(),
+        evolvesFrom = type.evolvesFrom,
+        healthPoints = type.hp,
+        number = type.number,
+        artist = type.artist,
+        rarity = type.rarity,
+        series = type.series,
+        set = type.set,
+        setCode = type.setCode
+    )
+
+    companion object {
+        private const val TYPE_VALUE = 0
+    }
+}

--- a/data/src/main/java/com/globant/data/service/PokemonCardDetailServiceImpl.kt
+++ b/data/src/main/java/com/globant/data/service/PokemonCardDetailServiceImpl.kt
@@ -1,0 +1,32 @@
+package com.globant.data.service
+
+import com.globant.data.mapper.PokemonCardDetailsMapper
+import com.globant.data.service.api.PokemonTCGApi
+import com.globant.domain.entity.PokemonCard
+import com.globant.domain.service.PokemonCardDetailService
+import com.globant.domain.util.Result
+
+class PokemonCardDetailServiceImpl : PokemonCardDetailService {
+    private val api = ServiceGenerator()
+    private val mapper = PokemonCardDetailsMapper()
+
+    override fun getPokemonCardDetail(pokemonCardId: String): Result<PokemonCard> {
+        try {
+            val callResponse = api.createService(PokemonTCGApi::class.java).getPokemonCardDetail(pokemonCardId)
+            val response = callResponse.execute()
+            if (response.isSuccessful)
+                response.body()?.card?.let {
+                    mapper.transform(it)
+                }?.let {
+                    return Result.Success(it)
+                }
+        } catch (e: Exception) {
+            return Result.Failure(Exception(NOT_FOUND))
+        }
+        return Result.Failure(Exception(NOT_FOUND))
+    }
+
+    companion object {
+        private const val NOT_FOUND = "Pokemon card not found"
+    }
+}

--- a/data/src/main/java/com/globant/data/service/api/PokemonTCGApi.kt
+++ b/data/src/main/java/com/globant/data/service/api/PokemonTCGApi.kt
@@ -1,11 +1,13 @@
 package com.globant.data.service.api
 
+import com.globant.data.service.response.PokemonCardDetailResponse
 import com.globant.data.service.response.PokemonCardListResponse
 import com.globant.data.service.response.PokemonSubtypesResponse
 import com.globant.data.service.response.PokemonSupertypesResponse
 import com.globant.data.service.response.PokemonTypesResponse
 import retrofit2.Call
 import retrofit2.http.GET
+import retrofit2.http.Path
 import retrofit2.http.QueryMap
 
 interface PokemonTCGApi {
@@ -20,4 +22,7 @@ interface PokemonTCGApi {
 
     @GET("v1/cards")
     fun getPokemonCardList(@QueryMap pokemonCardGroup: Map<String, String>): Call<PokemonCardListResponse>
+
+    @GET("v1/cards/{pokemonCardId}")
+    fun getPokemonCardDetail(@Path("pokemonCardId") pokemonCardId: String): Call<PokemonCardDetailResponse>
 }

--- a/data/src/main/java/com/globant/data/service/response/PokemonCardDetailResponse.kt
+++ b/data/src/main/java/com/globant/data/service/response/PokemonCardDetailResponse.kt
@@ -1,0 +1,5 @@
+package com.globant.data.service.response
+
+class PokemonCardDetailResponse(
+    var card: PokemonCardResponse
+)

--- a/data/src/main/java/com/globant/data/service/response/PokemonCardResponse.kt
+++ b/data/src/main/java/com/globant/data/service/response/PokemonCardResponse.kt
@@ -1,10 +1,21 @@
 package com.globant.data.service.response
 
+import com.globant.domain.util.NONE
+
 class PokemonCardResponse(
     var id: String,
     var name: String,
+    var nationalPokedexNumber: Int?,
     var imageUrl: String,
     var types: List<String>?,
     var supertype: String?,
-    var subtype: String?
+    var subtype: String?,
+    var evolvesFrom: String?,
+    var hp: String = NONE,
+    var number: String,
+    var artist: String,
+    var rarity: String,
+    var series: String,
+    var set: String,
+    var setCode: String
 )

--- a/data/src/main/java/com/globant/data/service/response/PokemonCardResponse.kt
+++ b/data/src/main/java/com/globant/data/service/response/PokemonCardResponse.kt
@@ -1,7 +1,5 @@
 package com.globant.data.service.response
 
-import com.globant.domain.util.NONE
-
 class PokemonCardResponse(
     var id: String,
     var name: String,
@@ -11,7 +9,7 @@ class PokemonCardResponse(
     var supertype: String?,
     var subtype: String?,
     var evolvesFrom: String?,
-    var hp: String = NONE,
+    var hp: String?,
     var number: String,
     var artist: String,
     var rarity: String,

--- a/data/src/main/java/com/globant/data/service/response/PokemonCardResponse.kt
+++ b/data/src/main/java/com/globant/data/service/response/PokemonCardResponse.kt
@@ -9,7 +9,7 @@ class PokemonCardResponse(
     var supertype: String?,
     var subtype: String?,
     var evolvesFrom: String?,
-    var hp: String?,
+    var hp: String,
     var number: String,
     var artist: String,
     var rarity: String,

--- a/di/src/main/java/com/globant/di/KoinModules.kt
+++ b/di/src/main/java/com/globant/di/KoinModules.kt
@@ -6,6 +6,7 @@ import com.globant.data.database.PokemonDatabase
 import com.globant.data.database.PokemonSubtypeDatabaseImpl
 import com.globant.data.database.PokemonSupertypeDatabaseImpl
 import com.globant.data.database.PokemonTypeDatabaseImpl
+import com.globant.data.service.PokemonCardDetailServiceImpl
 import com.globant.data.service.PokemonCardListServiceImpl
 import com.globant.data.service.PokemonSubtypesServiceImpl
 import com.globant.data.service.PokemonSupertypesServiceImpl
@@ -14,14 +15,17 @@ import com.globant.domain.database.PokemonCardDatabase
 import com.globant.domain.database.PokemonSubtypeDatabase
 import com.globant.domain.database.PokemonSupertypeDatabase
 import com.globant.domain.database.PokemonTypeDatabase
+import com.globant.domain.service.PokemonCardDetailService
 import com.globant.domain.service.PokemonCardListService
 import com.globant.domain.service.PokemonSubtypesService
 import com.globant.domain.service.PokemonSupertypesService
 import com.globant.domain.service.PokemonTypesService
+import com.globant.domain.usecase.GetPokemonCardDetailUseCase
 import com.globant.domain.usecase.GetPokemonCardListUseCase
 import com.globant.domain.usecase.GetPokemonSubtypesUseCase
 import com.globant.domain.usecase.GetPokemonSupertypesUseCase
 import com.globant.domain.usecase.GetPokemonTypesUseCase
+import com.globant.domain.usecase.implementation.GetPokemonCardDetailUseCaseImpl
 import com.globant.domain.usecase.implementation.GetPokemonCardListUseCaseImpl
 import com.globant.domain.usecase.implementation.GetPokemonSubtypesUseCaseImpl
 import com.globant.domain.usecase.implementation.GetPokemonSupertypesUseCaseImpl
@@ -33,6 +37,7 @@ val serviceModule = module {
     single<PokemonSupertypesService> { PokemonSupertypesServiceImpl() }
     single<PokemonSubtypesService> { PokemonSubtypesServiceImpl() }
     single<PokemonCardListService> { PokemonCardListServiceImpl() }
+    single<PokemonCardDetailService> { PokemonCardDetailServiceImpl() }
 }
 
 val useCaseModule = module {
@@ -40,6 +45,7 @@ val useCaseModule = module {
     single<GetPokemonSupertypesUseCase> { GetPokemonSupertypesUseCaseImpl(get(), get()) }
     single<GetPokemonSubtypesUseCase> { GetPokemonSubtypesUseCaseImpl(get(), get()) }
     single<GetPokemonCardListUseCase> { GetPokemonCardListUseCaseImpl(get(), get()) }
+    single<GetPokemonCardDetailUseCase> { GetPokemonCardDetailUseCaseImpl(get()) }
 }
 
 val databaseModule = module {

--- a/domain/src/main/java/com/globant/domain/entity/PokemonCardDetails.kt
+++ b/domain/src/main/java/com/globant/domain/entity/PokemonCardDetails.kt
@@ -1,11 +1,9 @@
 package com.globant.domain.entity
 
-import com.globant.domain.util.NONE
-
 class PokemonCardDetails(
-    var nationalPokedexNumber: String?,
+    var nationalPokedexNumber: Int?,
     var evolvesFrom: String?,
-    var healthPoints: String = NONE,
+    var healthPoints: String?,
     var number: String,
     var artist: String,
     var rarity: String,

--- a/domain/src/main/java/com/globant/domain/service/PokemonCardDetailService.kt
+++ b/domain/src/main/java/com/globant/domain/service/PokemonCardDetailService.kt
@@ -1,0 +1,8 @@
+package com.globant.domain.service
+
+import com.globant.domain.entity.PokemonCard
+import com.globant.domain.util.Result
+
+interface PokemonCardDetailService {
+    fun getPokemonCardDetail(pokemonCardId: String): Result<PokemonCard>
+}

--- a/domain/src/main/java/com/globant/domain/usecase/GetPokemonCardDetailUseCase.kt
+++ b/domain/src/main/java/com/globant/domain/usecase/GetPokemonCardDetailUseCase.kt
@@ -1,0 +1,8 @@
+package com.globant.domain.usecase
+
+import com.globant.domain.entity.PokemonCard
+import com.globant.domain.util.Result
+
+interface GetPokemonCardDetailUseCase {
+    fun invoke(pokemonCardId: String): Result<PokemonCard>
+}

--- a/domain/src/main/java/com/globant/domain/usecase/implementation/GetPokemonCardDetailUseCaseImpl.kt
+++ b/domain/src/main/java/com/globant/domain/usecase/implementation/GetPokemonCardDetailUseCaseImpl.kt
@@ -1,0 +1,10 @@
+package com.globant.domain.usecase.implementation
+
+import com.globant.domain.entity.PokemonCard
+import com.globant.domain.service.PokemonCardDetailService
+import com.globant.domain.usecase.GetPokemonCardDetailUseCase
+import com.globant.domain.util.Result
+
+class GetPokemonCardDetailUseCaseImpl(private val pokemonCardDetailService: PokemonCardDetailService) : GetPokemonCardDetailUseCase {
+    override fun invoke(pokemonCardId: String): Result<PokemonCard> = pokemonCardDetailService.getPokemonCardDetail(pokemonCardId)
+}

--- a/domain/src/main/java/com/globant/domain/util/Constants.kt
+++ b/domain/src/main/java/com/globant/domain/util/Constants.kt
@@ -2,4 +2,3 @@ package com.globant.domain.util
 
 const val FIRST_RESPONSE = 0
 const val SECOND_RESPONSE = 1
-const val NONE = "None"


### PR DESCRIPTION
In this PR I added the Service needed to do a request to the API and recover the Pokemon Card Details from a given Pokemon Card selected, removing the need to use mocked data.

- Built the structure of the request.
- Use the Service response instead of mocked data.
- Modified unit tests for the implementation.
- Fixed issues with empty or wrong response data.

Tests passing and coverage:

<img width="184" alt="tests passed details service" src="https://user-images.githubusercontent.com/61156888/89053113-1e167a00-d32d-11ea-86d7-892851221c0d.png">

<img width="230" alt="viewmodel coverage service" src="https://user-images.githubusercontent.com/61156888/89053116-1f47a700-d32d-11ea-8a69-f62e27e752f3.png">

<img width="230" alt="usecase coverage services" src="https://user-images.githubusercontent.com/61156888/89056452-6a17ed80-d332-11ea-828e-a10ae27681ff.png">

GIF of the app:

![details service gif](https://user-images.githubusercontent.com/61156888/89053551-c62c4300-d32d-11ea-8546-9e9764553fd3.gif)